### PR TITLE
Fix for Updating Script to 4.1.1 release Android App Release Version

### DIFF
--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -65,7 +65,7 @@ COPY ./config/gradle.properties ./gradle.properties.tutor
 RUN cat ./gradle.properties.tutor >> ./gradle.properties
 {% endif %}
 
-# uncomment thi line for for release APK. 
+# uncomment this line for for release APK. 
 # RUN sed -i "s/APPLICATION_ID = .*/APPLICATION_ID = \"{{ LMS_HOST|reverse_host|replace("-", "_") }}\"/g" constants.gradle
 RUN ./gradlew assembleProd{{ "Release" if ANDROID_ENABLE_RELEASE_MODE else "Debuggable" }}
 

--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -1,11 +1,11 @@
-FROM docker.io/ubuntu:22.04 AS base
+FROM docker.io/ubuntu:23.10 AS base
 LABEL maintainer="Overhang.IO <contact@overhang.io>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked {% endif %}apt update && \
   apt upgrade -y && \
-  apt install -y wget unzip git openjdk-11-jre openjdk-11-jdk
+  apt install -y wget unzip git openjdk-17-jre openjdk-17-jdk
 
 RUN mkdir /app
 
@@ -15,7 +15,7 @@ FROM base AS sdk
 # Install Android SDK
 # Inspired from https://github.com/LiveXP/docker-android-sdk/blob/master/Dockerfile
 # Get sdk version from here: https://developer.android.com/studio#command-tools
-ENV ANDROID_SDK_VERSION 9477386
+ENV ANDROID_SDK_VERSION 10406996
 ENV ANDROID_SDK_PATH /app/android-sdk
 ENV ANDROID_HOME /app/android-sdk
 RUN mkdir ${ANDROID_HOME}
@@ -27,13 +27,15 @@ RUN wget --quiet https://dl.google.com/android/repository/commandlinetools-linux
 # Accept licenses
 # https://developer.android.com/studio/command-line/sdkmanager
 # Check target version: https://github.com/edx/edx-app-android/blob/master/constants.gradle
-ARG ANDROID_API_LEVEL=31
+ARG ANDROID_API_LEVEL=33
 RUN yes | /app/android-sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install "platforms;android-$ANDROID_API_LEVEL" 1> /dev/null
 
 ###### Checkout code
 FROM base AS code
 # Install android app repo
 ARG ANDROID_APP_REPOSITORY=https://github.com/openedx/edx-app-android
+
+# Please add ANDROID_APP_VERSION value in tutor config from release version https://github.com/openedx/edx-app-android/tags
 ARG ANDROID_APP_VERSION=release/{{ ANDROID_APP_VERSION }}
 RUN git clone $ANDROID_APP_REPOSITORY --branch $ANDROID_APP_VERSION /app/edx-app-android
 
@@ -63,7 +65,8 @@ COPY ./config/gradle.properties ./gradle.properties.tutor
 RUN cat ./gradle.properties.tutor >> ./gradle.properties
 {% endif %}
 
-RUN sed -i "s/APPLICATION_ID = .*/APPLICATION_ID = \"{{ LMS_HOST|reverse_host|replace("-", "_") }}\"/g" constants.gradle
+# uncomment thi line for for release APK. 
+# RUN sed -i "s/APPLICATION_ID = .*/APPLICATION_ID = \"{{ LMS_HOST|reverse_host|replace("-", "_") }}\"/g" constants.gradle
 RUN ./gradlew assembleProd{{ "Release" if ANDROID_ENABLE_RELEASE_MODE else "Debuggable" }}
 
 #### File server to serve apk file


### PR DESCRIPTION
- Updated Ubuntu version to 23.10
- Updated JDK and JRE version to 17
- Commented application ID updation line.
- Updated API level to 33
