### PR TITLE
BUILD  Removed IMAGES_BUILD_PLATFORM Key from the Gitlab CI File

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ variables:
     TUTOR_PYPI_PACKAGE: tutor-android
     OPENEDX_RELEASE: palm
     GITHUB_REPO: overhangio/tutor-android
-    IMAGES_BUILD_PLATFORM: "linux/amd64"
 
 include:
   - project: 'community/tutor-ci'


### PR DESCRIPTION
As suggested [here](https://github.com/overhangio/tutor-android/issues/7#issuecomment-1903892852) 