### PR TITLE
Update ANDROID_APP_VERSION to be dynamic based on OPENEDX_COMMON_VERSION

### DIFF
--- a/changelog.d/20240610_212617_hamzashafiquehere_dynamic_android_app_version.md
+++ b/changelog.d/20240610_212617_hamzashafiquehere_dynamic_android_app_version.md
@@ -1,0 +1,1 @@
+- [Feature] Enhanced `ANDROID_APP_VERSION` logic to dynamically set the version based on `OPENEDX_COMMON_VERSION`: For nightly builds, `ANDROID_APP_VERSION` is set to main. For other builds, `ANDROID_APP_VERSION` is set to the value of `OPENEDX_COMMON_VERSION`. (by @hamza-56)

--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -35,8 +35,7 @@ RUN yes | /app/android-sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_HOM
 FROM base AS code
 # Install android app repo
 ARG ANDROID_APP_REPOSITORY=https://github.com/openedx/openedx-app-android.git
-# Always use the 'main' branch
-ARG ANDROID_APP_VERSION=main
+ARG ANDROID_APP_VERSION={% if OPENEDX_COMMON_VERSION == "master" %}main{% else %}{{ OPENEDX_COMMON_VERSION }}{% endif %}
 ADD --keep-git-dir $ANDROID_APP_REPOSITORY#$ANDROID_APP_VERSION /app/openedx-app-android
 
 ###### Empty layer to mount custom repo at build time


### PR DESCRIPTION
This PR updates the logic for setting the `ANDROID_APP_VERSION` in the Dockerfile. The new logic uses a conditional statement to determine the value based on the `OPENEDX_COMMON_VERSION` variable.

For the nightly build, set `ANDROID_APP_VERSION` to `main`.
For master and redwood branches, set `ANDROID_APP_VERSION` to the value of `OPENEDX_COMMON_VERSION`.