### PR TITLE
feat: upgrade Android SDK and API level to latest versions

### DIFF
--- a/changelog.d/20251105_200539_abdul.muqadim_upgrade_android_sdk_tools_api36.md
+++ b/changelog.d/20251105_200539_abdul.muqadim_upgrade_android_sdk_tools_api36.md
@@ -1,0 +1,1 @@
+- [Improvement] Upgraded Android build configuration to use latest SDK and API versions (`ANDROID_API_LEVEL=36`, `ANDROID_SDK_VERSION=13114758`) to ensure compatibility with the latest Android tools. (by @Abdul-Muqadim-Arbisoft)

--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -16,7 +16,7 @@ FROM base AS sdk
 # Install Android SDK
 # Inspired from https://github.com/LiveXP/docker-android-sdk/blob/master/Dockerfile
 # Get sdk version from here: https://developer.android.com/studio#command-tools
-ENV ANDROID_SDK_VERSION=11076708
+ENV ANDROID_SDK_VERSION=13114758
 ENV ANDROID_SDK_PATH=/app/android-sdk
 ENV ANDROID_HOME=/app/android-sdk
 RUN mkdir ${ANDROID_HOME}
@@ -28,7 +28,7 @@ RUN wget --quiet https://dl.google.com/android/repository/commandlinetools-linux
 # Accept licenses
 # https://developer.android.com/studio/command-line/sdkmanager
 # Check target version: https://github.com/edx/edx-app-android/blob/master/constants.gradle
-ARG ANDROID_API_LEVEL=34
+ARG ANDROID_API_LEVEL=36
 RUN yes | /app/android-sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install "platforms;android-$ANDROID_API_LEVEL" 1> /dev/null
 
 ###### Checkout code


### PR DESCRIPTION
Updated Android build Dockerfile to:
- Use ANDROID_API_LEVEL=36
- Use ANDROID_SDK_VERSION=13114758
This keeps the Tutor Android plugin compatible with the latest Android Studio and build tools.