### PR TITLE
fix: force amd64 base image for Android SDK build compatibility on Apple Silicon

### DIFF
--- a/changelog.d/20251105_201256_abdul.muqadim_fix_android_dockerfile_arm64_compatible.md
+++ b/changelog.d/20251105_201256_abdul.muqadim_fix_android_dockerfile_arm64_compatible.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix Android build on Apple Silicon by forcing the base Docker image to use `linux/amd64`, ensuring Android SDK and Gradle tools run correctly across all platforms. (by @Abdul-Muqadim-Arbisoft)

--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM docker.io/ubuntu:24.04 AS base
+FROM --platform=linux/amd64 docker.io/ubuntu:24.04 AS base
 LABEL maintainer="Overhang.IO <contact@overhang.io>"
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Android SDK and Gradle tools are distributed only as x86_64 binaries. When building the Android Docker image on ARM-based machines (e.g., Apple M1/M2), the build fails with “failed to open ELF” errors due to architecture mismatch.

This change pins the Docker base image to linux/amd64 explicitly:

    FROM --platform=linux/amd64 docker.io/ubuntu:24.04 AS base

This ensures consistent behavior across Intel and Apple Silicon hosts, resolving build failures without affecting Intel users.