### PR TITLE
fix: app version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info/
 /build/
 /dist/
+.venv/

--- a/README.rst
+++ b/README.rst
@@ -1,36 +1,44 @@
 Android application plugin for `Tutor <https://docs.tutor.edly.io>`__
-=========================================================================
+=====================================================================
 
 This is a plugin to easily build an Android mobile application for your `Open edX <https://open.edx.org>`__ instance.
 
 Installation
 ------------
 
-::
+.. code-block:: bash
 
     tutor plugins install android
 
 Usage
 -----
 
-Enable the plugin and start the platform::
+Enable the plugin and start the platform:
+
+.. code-block:: bash
 
     tutor plugins enable android
     tutor local launch
 
-The ``.apk`` file will then be available for download at http(s)://mobile.LMS_HOST/app.apk. When running locally, this will be: http://mobile.local.openedx.io/app.apk. You can forward this address to your students for download.
+The ``.apk`` file will then be available for download at http(s)://mobile.LMS_HOST/app.apk. When running locally,
+this will be: http://mobile.local.openedx.io/app.apk. You can forward this address to your students for download.
 
 Building a custom Android app
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Android app is built from the `official openedx-app-android repository <https://github.com/openedx/openedx-app-android/>`__. To change this repository or the app version, you can simply build a different docker image with::
+The Android app is built from the `official openedx-app-android repository <https://github.com/openedx/openedx-app-android/>`__.
+To change this repository or the app version, you can simply build a different docker image with:
+
+.. code-block:: bash
 
     tutor images build \
         --build-arg ANDROID_APP_REPOSITORY=https://github.com/mycustomfork/openedx-app-android \
         --build-arg ANDROID_APP_VERSION=master \
         android
 
-Alternatively, you can build an image from a local checked-out fork of openedx-app-android::
+Alternatively, you can build an image from a local checked-out fork of openedx-app-android:
+
+.. code-block:: bash
 
     tutor mounts add /path/to/openedx-app-android
     tutor local launch
@@ -38,7 +46,8 @@ Alternatively, you can build an image from a local checked-out fork of openedx-a
 Making courses visible in app
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, courses are not visible in the mobile app. To make them available, go to Studio → YOUR COURSE → Settings → Advanced Settings and set ``Mobile Course Available`` to true.
+By default, courses are not visible in the mobile app. To make them available, go to
+Studio → YOUR COURSE → Settings → Advanced Settings and set ``Mobile Course Available`` to true.
 
 
 Releasing an Android app
@@ -46,7 +55,10 @@ Releasing an Android app
 
 **Note**: this is an untested feature.
 
-Releasing an Android app on the Play Store requires to build the app in release mode. To do so, modify the following Tutor settings::
+Releasing an Android app on the Play Store requires to build the app in release mode. To do so,
+modify the following Tutor settings:
+
+.. code-block:: bash
 
     tutor config save \
       --set ANDROID_RELEASE_STORE_PASSWORD=yourstorepassword \
@@ -54,14 +66,18 @@ Releasing an Android app on the Play Store requires to build the app in release 
       --set ANDROID_RELEASE_KEY_ALIAS=yourreleasekeyalias \
       --set ANDROID_ENABLE_RELEASE_MODE=true
 
-Then, place your keystore file in ``$(tutor config printroot)/env/plugins/android/build/app/config/app.keystore``. Finally, rebuild the image by starting the "android-app" container::
+Then, place your keystore file in ``$(tutor config printroot)/env/plugins/android/build/app/config/app.keystore``.
+Finally, rebuild the image by starting the "android-app" container:
+
+.. code-block:: bash
 
     tutor local start -d android-app
 
 Customising the Android app
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Customising the application, such as the logo or the background image, is currently not supported. If you are interested by this feature, please tell us about it in the Tutor `discussion forums <https://discuss.overhang.io>`_.
+Customising the application, such as the logo or the background image, is currently not supported.
+If you are interested by this feature, please tell us about it in the Tutor `discussion forums <https://discuss.overhang.io>`_.
 
 Troubleshooting
 ---------------

--- a/changelog.d/20260113_122626_codewithemad_app_version.md
+++ b/changelog.d/20260113_122626_codewithemad_app_version.md
@@ -1,0 +1,3 @@
+
+- [Improvement] `ANDROID_APP_VERSION` and `ANDROID_APP_REPOSITORY` values now set correctly in `Dockerfile` (by @CodeWithEmad)
+- [Feature] `ANDROID_APP_ID` introduced to set the `APPLICATION_ID` inside `tutor.yaml` (by @CodeWithEmad)

--- a/tutorandroid/plugin.py
+++ b/tutorandroid/plugin.py
@@ -20,9 +20,7 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
     "defaults": {
         "VERSION": __version__,
         "APP_HOST": "mobile.{{ LMS_HOST }}",
-        # Version 4.0.0 is not working:
-        # https://github.com/overhangio/tutor-android/pull/6#issuecomment-1541510489
-        "APP_VERSION": "3.1.4",
+        "APP_VERSION": '{% if OPENEDX_COMMON_VERSION == "master" %}main{% else %}{{ OPENEDX_COMMON_VERSION }}{% endif %}',  # noqa: E501
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-android:{{ ANDROID_VERSION }}",  # noqa: E501
         "APP_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-android-app:{{ ANDROID_VERSION }}",  # noqa: E501
         "ENABLE_RELEASE_MODE": False,

--- a/tutorandroid/plugin.py
+++ b/tutorandroid/plugin.py
@@ -21,6 +21,7 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
         "VERSION": __version__,
         "APP_HOST": "mobile.{{ LMS_HOST }}",
         "APP_VERSION": '{% if OPENEDX_COMMON_VERSION == "master" %}main{% else %}{{ OPENEDX_COMMON_VERSION }}{% endif %}',  # noqa: E501
+        "APP_ID": "org.openedx.app",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-android:{{ ANDROID_VERSION }}",  # noqa: E501
         "APP_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-android-app:{{ ANDROID_VERSION }}",  # noqa: E501
         "ENABLE_RELEASE_MODE": False,

--- a/tutorandroid/plugin.py
+++ b/tutorandroid/plugin.py
@@ -20,8 +20,9 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
     "defaults": {
         "VERSION": __version__,
         "APP_HOST": "mobile.{{ LMS_HOST }}",
-        "APP_VERSION": '{% if OPENEDX_COMMON_VERSION == "master" %}main{% else %}{{ OPENEDX_COMMON_VERSION }}{% endif %}',  # noqa: E501
         "APP_ID": "org.openedx.app",
+        "APP_REPOSITORY": "https://github.com/openedx/openedx-app-android.git",
+        "APP_VERSION": '{% if OPENEDX_COMMON_VERSION == "master" %}main{% else %}{{ OPENEDX_COMMON_VERSION }}{% endif %}',  # noqa: E501
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-android:{{ ANDROID_VERSION }}",  # noqa: E501
         "APP_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/openedx-android-app:{{ ANDROID_VERSION }}",  # noqa: E501
         "ENABLE_RELEASE_MODE": False,

--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -35,7 +35,7 @@ RUN yes | /app/android-sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_HOM
 FROM base AS code
 # Install android app repo
 ARG ANDROID_APP_REPOSITORY=https://github.com/openedx/openedx-app-android.git
-ARG ANDROID_APP_VERSION={% if OPENEDX_COMMON_VERSION == "master" %}main{% else %}{{ OPENEDX_COMMON_VERSION }}{% endif %}
+ARG ANDROID_APP_VERSION={{ ANDROID_APP_VERSION }}
 ADD --keep-git-dir $ANDROID_APP_REPOSITORY#$ANDROID_APP_VERSION /app/openedx-app-android
 
 ###### Empty layer to mount custom repo at build time

--- a/tutorandroid/templates/android/build/Dockerfile
+++ b/tutorandroid/templates/android/build/Dockerfile
@@ -34,7 +34,7 @@ RUN yes | /app/android-sdk/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_HOM
 ###### Checkout code
 FROM base AS code
 # Install android app repo
-ARG ANDROID_APP_REPOSITORY=https://github.com/openedx/openedx-app-android.git
+ARG ANDROID_APP_REPOSITORY={{ ANDROID_APP_REPOSITORY }}
 ARG ANDROID_APP_VERSION={{ ANDROID_APP_VERSION }}
 ADD --keep-git-dir $ANDROID_APP_REPOSITORY#$ANDROID_APP_VERSION /app/openedx-app-android
 

--- a/tutorandroid/templates/android/build/config/tutor.yaml
+++ b/tutorandroid/templates/android/build/config/tutor.yaml
@@ -1,6 +1,6 @@
 # See docs: https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/48792067/App+Configuration+Flags
 API_HOST_URL: "{{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}"
-APPLICATION_ID: 'org.openedx.app'
+APPLICATION_ID: "{{ ANDROID_APP_ID }}"
 ENVIRONMENT_DISPLAY_NAME: "tutor"
 URI_SCHEME: ''
 FEEDBACK_EMAIL_ADDRESS: "{{ CONTACT_EMAIL }}"
@@ -35,7 +35,7 @@ FIREBASE:
   CLOUD_MESSAGING_ENABLED: false
   PROJECT_NUMBER: ''
   PROJECT_ID: ''
-  APPLICATION_ID: '' #App ID field from the Firebase console or mobilesdk_app_id from the google-services.json file.
+  APPLICATION_ID: '' # App ID field from the Firebase console or mobilesdk_app_id from the google-services.json file.
   API_KEY: ''
 
 SEGMENT_IO:


### PR DESCRIPTION
I know we can pass arguments to dockerfile, but why not using the tutor configs?
This fixes the app version issue, introduces `ANDROID_APP_ID` to set the `APPLICATION_ID` inside `tutor.yml`,  and enhances the readme for better readability and syntax highlighting.


Close #46 